### PR TITLE
MSVC2019-WIN64

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-注：修改了部分代码，适合win平台，MSVC 2019
+2021.06.22 注：
+修改了部分代码，适合win平台，MSVC 2019
 
 # DeepSort_TensorRT
 TensorRT真是太快啦，基于大佬实现的DeepSort，用TensorRT来做特征提取的部分。[慢更]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+注：修改了部分代码，适合win平台，MSVC 2019
+
 # DeepSort_TensorRT
 TensorRT真是太快啦，基于大佬实现的DeepSort，用TensorRT来做特征提取的部分。[慢更]
 

--- a/include/deepsort.h
+++ b/include/deepsort.h
@@ -1,5 +1,11 @@
-#ifndef DEEPSORT_H
-#define DEEPSORT_H
+//#ifndef DEEPSORT_H
+//#define DEEPSORT_H
+
+#ifdef _DLL_EXPORTS
+#define DLL_API _declspec(dllexport)
+#else
+#define DLL_API _declspec(dllimport)
+#endif
 
 #include <iostream>
 #include <opencv2/opencv.hpp>
@@ -11,7 +17,7 @@
 using std::vector;
 using nvinfer1::ILogger;
 
-class DeepSort {
+class DLL_API DeepSort {
 public:    
     DeepSort(std::string modelPath, int batchSize, int featureDim, int gpuID, ILogger* gLogger);
     ~DeepSort();
@@ -45,4 +51,4 @@ private:
     int gpuID;
 };
 
-#endif  //deepsort.h
+//#endif  //deepsort.h

--- a/include/deepsortenginegenerator.h
+++ b/include/deepsortenginegenerator.h
@@ -1,5 +1,11 @@
-#ifndef DEEPSORT_ENGINE_GENERATOR_H
-#define DEEPSORT_ENGINE_GENERATOR_H
+//#ifndef DEEPSORT_ENGINE_GENERATOR_H
+//#define DEEPSORT_ENGINE_GENERATOR_H
+
+#ifdef _DLL_EXPORTS
+#define DLL_API _declspec(dllexport)
+#else
+#define DLL_API _declspec(dllimport)
+#endif
 
 #include <iostream>
 #include <NvInfer.h>
@@ -12,7 +18,7 @@ const int IMG_WIDTH = 64;
 const int MAX_BATCH_SIZE = 128;
 const std::string INPUT_NAME("input");
 
-class DeepSortEngineGenerator {
+class DLL_API DeepSortEngineGenerator {
 public:
     DeepSortEngineGenerator(ILogger* gLogger);
     ~DeepSortEngineGenerator();
@@ -27,4 +33,4 @@ private:
     bool useFP16; 
 };
 
-#endif
+//#endif

--- a/src/deepsort.cpp
+++ b/src/deepsort.cpp
@@ -1,3 +1,5 @@
+#define _DLL_EXPORTS
+
 #include "deepsort.h"
 
 DeepSort::DeepSort(std::string modelPath, int batchSize, int featureDim, int gpuID, ILogger* gLogger) {

--- a/src/deepsortenginegenerator.cpp
+++ b/src/deepsortenginegenerator.cpp
@@ -49,7 +49,7 @@ void DeepSortEngineGenerator::createEngine(std::string onnxPath, std::string eng
     std::ofstream serializeOutputStream;
     serializeStr.resize(modelStream->size());
     memcpy((void*)serializeStr.data(), modelStream->data(), modelStream->size());
-    serializeOutputStream.open(enginePath);
+    serializeOutputStream.open(enginePath, std::ios::binary);      //add std::ios::binary for windows platform
     serializeOutputStream << serializeStr;
     serializeOutputStream.close();
 }

--- a/src/deepsortenginegenerator.cpp
+++ b/src/deepsortenginegenerator.cpp
@@ -1,3 +1,5 @@
+#define _DLL_EXPORTS
+
 #include "deepsortenginegenerator.h"
 #include "assert.h"
 #include <memory.h> 

--- a/src/featuretensor.cpp
+++ b/src/featuretensor.cpp
@@ -63,7 +63,7 @@ void FeatureTensor::loadEngine(std::string enginePath) {
     // Deserialize model
     runtime = createInferRuntime(*gLogger);
     assert(runtime != nullptr);
-    std::ifstream engineStream(enginePath);
+    std::ifstream engineStream(enginePath, std::ios::binary);
     std::string engineCache("");
     while (engineStream.peek() != EOF) {
         std::stringstream buffer;


### PR DESCRIPTION
1 : for MSVC export .dll and .lib
2 : add std::ios::binary for windows platform, otherwise developer will meet error:
> ERROR: C:\source\rtSafe\coreReadArchive.cpp (55) - Serialization Error in nvinfer1::rt::CoreReadArchive::verifyHeader: 0 (Length in header does not match remaining archive length)
ERROR: INVALID_STATE: Unknown exception
ERROR: INVALID_CONFIG: Deserialize the cuda engine failed.